### PR TITLE
Add double quotes around expected format and error

### DIFF
--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -31,44 +31,68 @@ describe(utils.getIssuerFromTitle.name, () => {
         expect(utils.getIssuerFromTitle('Import the correct ZAPI - WEBTV-3388'))
     });
 
-    it('returns error for a title with invalid code format', () => {
-        expect(utils.getIssuerFromTitle('webtv-338: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+    it("returns error for a title with invalid code format", () => {
+        let title = "webtv-338: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('WEB-XXX: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "WEB-XXX: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('WEB-1XX: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "WEB-1XX: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('111-111: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "111-111: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('111-WEV: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "111-WEV: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('WEB111: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "WEB111: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('WEB:111: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "WEB:111: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('WEB_111: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "WEB_111: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('wEB_111: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "wEB_111: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
     });
 
-    it('returns error if one or more of multiple codes is are invalid', () => {
-        expect(utils.getIssuerFromTitle('WEB-111, WEB-2X: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+    it("returns error if one or more of multiple codes is are invalid", () => {
+        let title = "WEB-111, WEB-2X: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('WEB-111, WEB-2-: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "WEB-111, WEB-2-: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
 
-        expect(utils.getIssuerFromTitle('WEB-X11, WEB-22-: Import the correct ZAPI'))
-            .toEqual({error: errors.FORMAT_ERROR});
+        title = "WEB-X11, WEB-22-: Import the correct ZAPI";
+        expect(utils.getIssuerFromTitle(title)).toEqual({
+            error: `${errors.FORMAT_ERROR}. Found: "${title}"`,
+        });
     });
 
     it('returns error if no space after separator', () => {

--- a/src/constants/errors.js
+++ b/src/constants/errors.js
@@ -1,4 +1,4 @@
-const EXPECTED_PATTERN = 'Expected pattern is CODE-XXX [, CODE-XXX]: Title';
+const EXPECTED_PATTERN = 'Expected pattern is "CODE-XXX [, CODE-XXX]: Title"';
 const FORMAT_ERROR = `Format is invalid. ${EXPECTED_PATTERN}`;
 const REFERENCE_ERROR = `Issuer reference is missing. ${EXPECTED_PATTERN}`;
 const SPACE_ERROR = `Title should have space after the separator. ${EXPECTED_PATTERN}`;
@@ -8,5 +8,5 @@ module.exports = {
     FORMAT_ERROR,
     REFERENCE_ERROR,
     SPACE_ERROR,
-    UPPERCASE_ERROR
+    UPPERCASE_ERROR,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ const getIssuerFromTitle = (title) => {
 
     for (const ticket of tickets) {
         if (!codeRegex.test(ticket)) {
-            return { error: `${errors.FORMAT_ERROR}. Found: "${ticket}"` };
+            return { error: `${errors.FORMAT_ERROR}. Found: "${title}"` };
         }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,8 +24,10 @@ const getIssuerFromTitle = (title) => {
         return {error: errors.REFERENCE_ERROR};
     }
 
-    if(tickets.some((ticket) => !codeRegex.test(ticket))) {
-        return {error: errors.FORMAT_ERROR};
+    for (const ticket of tickets) {
+        if (!codeRegex.test(ticket)) {
+            return { error: `${errors.FORMAT_ERROR}. Found: "${ticket}"` };
+        }
     }
 
     if(titleString[0] !== ' ') {


### PR DESCRIPTION
Improve error message for format errors, making it easier to spot redundant white spaces 